### PR TITLE
feat: add support to provide a `node-version-file` in setup action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -37,7 +37,7 @@ inputs:
     description: "Node version"
     required: false
     default: "22.13.0"
-  node-version-file:
+  node_version_file:
     description: "File containing the version Spec of the version to use.  Examples: .nvmrc, .tool-versions, etc."
     required: false
 runs:
@@ -47,7 +47,7 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node_version }}
-        node-version-file: ${{ inputs.node-version-file }}
+        node-version-file: ${{ inputs.node_version_file }}
 
     - name: Install yarn
       run: corepack enable

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -37,6 +37,9 @@ inputs:
     description: "Node version"
     required: false
     default: "22.13.0"
+  node-version-file:
+    description: "File containing the version Spec of the version to use.  Examples: .nvmrc, .tool-versions, etc."
+    required: false
 runs:
   using: "composite"
   steps:
@@ -44,6 +47,7 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node_version }}
+        node-version-file: ${{ inputs.node-version-file }}
 
     - name: Install yarn
       run: corepack enable


### PR DESCRIPTION
Tested this here:
- https://github.com/Chili-Piper/chilical-scheduler/pull/749/commits/69126f813b615c5eb4afb05eae2207af3a696a21
- https://github.com/Chili-Piper/chilical-scheduler/actions/runs/17164449760/job/48701377239