### PR TITLE
fix: honor `node_version_file` when set

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -43,6 +43,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
+        fetch-depth: ${{ inputs.fetch-depth }}
+
     - name: Setup Node.js (from file)
       if: ${{ inputs.node_version_file }}
       uses: actions/setup-node@v4
@@ -57,12 +63,6 @@ runs:
     - name: Install yarn
       run: corepack enable
       shell: bash
-
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ inputs.ref }}
-        fetch-depth: ${{ inputs.fetch-depth }}
 
     - name: Cache node_modules
       if: inputs.cache == 'true'

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -43,11 +43,16 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup Node.js environment
+    - name: Setup Node.js (from file)
+      if: ${{ inputs.node_version_file }}
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: ${{ inputs.node_version_file }}
+    - name: Setup Node.js (from version)
+      if: ${{ ! inputs.node_version_file }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node_version }}
-        node-version-file: ${{ inputs.node_version_file }}
 
     - name: Install yarn
       run: corepack enable


### PR DESCRIPTION
Related to https://github.com/Chili-Piper/frontend-actions/pull/84.

Tested `node_version_file` here: https://github.com/Chili-Piper/chilical-scheduler/actions/runs/17167163655/job/48710185232?pr=749.
Tested `node_version` here: https://github.com/Chili-Piper/chilical-scheduler/actions/runs/17167264698/job/48710302050